### PR TITLE
basic editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
add a basic editorconfig file to proclaim the glory of TABS while keeping npm happy with it's grubby spaces in *.json files
closes #7