### PR TITLE
Feature/namespaces

### DIFF
--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -7,10 +7,12 @@
  * @package theme-scaffold
  */
 
+namespace ThemeScaffold\BlockPatterns;
+
 /**
  * Register block patterns.
  */
-function theme_scaffold_register_block_patterns() {
+function register() {
 	/*
 	register_block_pattern(
 		'theme-scaffold/example-pattern',
@@ -22,4 +24,4 @@ function theme_scaffold_register_block_patterns() {
 	);
 	*/
 }
-add_action( 'init', 'theme_scaffold_register_block_patterns' );
+add_action( 'init', __NAMESPACE__ . 'register' );

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -24,4 +24,4 @@ function register() {
 	);
 	*/
 }
-add_action( 'init', __NAMESPACE__ . 'register' );
+add_action( 'init', __NAMESPACE__ . '\\register' );

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -5,10 +5,12 @@
  * @package theme-scaffold
  */
 
+namespace ThemeScaffold\BlockStyles;
+
 /**
  * Register block styles.
  */
-function theme_scaffold_block_styles() {
+function register() {
 	// Lead Paragraph: paragraph with large, bold text.
 	register_block_style(
 		'core/paragraph',
@@ -29,4 +31,4 @@ function theme_scaffold_block_styles() {
 		)
 	);
 }
-add_action( 'init', 'theme_scaffold_block_styles' );
+add_action( 'init', __NAMESPACE__ . 'register' );

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -31,4 +31,4 @@ function register() {
 		)
 	);
 }
-add_action( 'init', __NAMESPACE__ . 'register' );
+add_action( 'init', __NAMESPACE__ . '\\register' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -5,12 +5,14 @@
  * @package theme-scaffold
  */
 
+namespace ThemeScaffold\Customizer;
+
 /**
  * Add postMessage support for site title and description for the Theme Customizer.
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
-function theme_scaffold_customize_register( $wp_customize ) {
+function register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
@@ -20,26 +22,26 @@ function theme_scaffold_customize_register( $wp_customize ) {
 			'blogname',
 			array(
 				'selector'        => '.site-title a',
-				'render_callback' => 'theme_scaffold_customize_partial_blogname',
+				'render_callback' => __NAMESPACE__ . '\\partial_blogname',
 			)
 		);
 		$wp_customize->selective_refresh->add_partial(
 			'blogdescription',
 			array(
 				'selector'        => '.site-description',
-				'render_callback' => 'theme_scaffold_customize_partial_blogdescription',
+				'render_callback' => __NAMESPACE__ . '\\partial_blogdescription',
 			)
 		);
 	}
 }
-add_action( 'customize_register', 'theme_scaffold_customize_register' );
+add_action( 'customize_register', __NAMESPACE__ . '\\register' );
 
 /**
  * Render the site title for the selective refresh partial.
  *
  * @return void
  */
-function theme_scaffold_customize_partial_blogname() {
+function partial_blogname() {
 	bloginfo( 'name' );
 }
 
@@ -48,15 +50,15 @@ function theme_scaffold_customize_partial_blogname() {
  *
  * @return void
  */
-function theme_scaffold_customize_partial_blogdescription() {
+function partial_blogdescription() {
 	bloginfo( 'description' );
 }
 
 /**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
-function theme_scaffold_customize_preview_js() {
+function preview_js() {
 	$customizerjs_asset = require get_template_directory() . '/dist/js/customizer.asset.php';
 	wp_enqueue_script( 'theme-scaffold-customizer', get_template_directory_uri() . '/js/customizer.js', array_merge( array( 'customize-preview' ), $customizerjs_asset['dependencies'] ), $customizerjs_asset['version'], true );
 }
-add_action( 'customize_preview_init', 'theme_scaffold_customize_preview_js' );
+add_action( 'customize_preview_init', __NAMESPACE__ . '\\preview_js' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -26,7 +26,7 @@ function body_classes( $classes ) {
 
 	return $classes;
 }
-add_filter( 'body_class', __NAMESPACE__ . 'body_classes' );
+add_filter( 'body_class', __NAMESPACE__ . '\\body_classes' );
 
 /**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.
@@ -36,4 +36,4 @@ function pingback_header() {
 		printf( '<link rel="pingback" href="%s">', esc_url( get_bloginfo( 'pingback_url' ) ) );
 	}
 }
-add_action( 'wp_head', __NAMESPACE__ . 'pingback_header' );
+add_action( 'wp_head', __NAMESPACE__ . '\\pingback_header' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Functions which enhance the theme by hooking into WordPress
+ * Functions which enhance the theme by hooking into WordPress.
  *
  * @package theme-scaffold
  */
+
+namespace ThemeScaffold\Hooks;
 
 /**
  * Adds custom classes to the array of body classes.
@@ -11,7 +13,7 @@
  * @param array $classes Classes for the body element.
  * @return array
  */
-function theme_scaffold_body_classes( $classes ) {
+function body_classes( $classes ) {
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
@@ -24,14 +26,14 @@ function theme_scaffold_body_classes( $classes ) {
 
 	return $classes;
 }
-add_filter( 'body_class', 'theme_scaffold_body_classes' );
+add_filter( 'body_class', __NAMESPACE__ . 'body_classes' );
 
 /**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.
  */
-function theme_scaffold_pingback_header() {
+function pingback_header() {
 	if ( is_singular() && pings_open() ) {
 		printf( '<link rel="pingback" href="%s">', esc_url( get_bloginfo( 'pingback_url' ) ) );
 	}
 }
-add_action( 'wp_head', 'theme_scaffold_pingback_header' );
+add_action( 'wp_head', __NAMESPACE__ . 'pingback_header' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -11,7 +11,7 @@ namespace ThemeScaffold\Hooks;
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array
+ * @return array Modified classes for the body element.
  */
 function body_classes( $classes ) {
 	// Adds a class of hfeed to non-singular pages.
@@ -27,6 +27,28 @@ function body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', __NAMESPACE__ . '\\body_classes' );
+
+/**
+ * Remove "Archive: " prefix from archive titles.
+ *
+ * @param string $title Current archive title.
+ * @return string Modified archive title.
+ */
+function archive_title( $title ) {
+	if ( is_category() ) {
+		$title = single_cat_title( '', false );
+	} elseif ( is_tag() ) {
+		$title = single_tag_title( '', false );
+	} elseif ( is_author() ) {
+		$title = '<span class="vcard">' . get_the_author() . '</span>';
+	} elseif ( is_tax() ) { // for custom post types
+		$title = sprintf( __( '%1$s' ), single_term_title( '', false ) );
+	} elseif ( is_post_type_archive() ) {
+		$title = post_type_archive_title( '', false );
+	}
+	return $title;
+}
+add_filter( 'get_the_archive_title', __NAMESPACE__ . '\\archive_title' );
 
 /**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.


### PR DESCRIPTION
Use namespaces almost everywhere. The code is more copy/pastable between projects and easier to pull back into the scaffolding.