### PR TITLE
Move alignment classes to layout mixin

### DIFF
--- a/src/styles/tools/_layout.scss
+++ b/src/styles/tools/_layout.scss
@@ -29,6 +29,29 @@
 }
 
 /**
+ * Generates alignment classes.
+ */
+@mixin alignments() {
+	.alignnarrow {
+		@include align('narrow');
+	}
+
+	.alignwide {
+		@include align('wide');
+	}
+
+	.alignextrawide {
+		@include align('extra-wide');
+	}
+
+	.alignfull {
+		max-width: none;
+		width: auto !important; // Fixes width: 100% when parent has padding.
+		margin-inline: calc( #{theme.get-var( 'sizes', 'gutter' )} * -1 );
+	}
+}
+
+/**
  * Applies the container mixin to the element and a default align to immediate
  * child elements.
  *
@@ -40,4 +63,6 @@
 	> * {
 		@include align();
 	}
+
+	@include alignments();
 }

--- a/src/styles/utilities/_alignments.scss
+++ b/src/styles/utilities/_alignments.scss
@@ -5,32 +5,7 @@
 @use '../settings/theme';
 @use '../tools/layout';
 
-.alignnarrow,
-.alignwide,
-.alignextrawide,
-.alignfull {
-	> * {
-		max-width: unset;
-	}
-}
-
-.alignnarrow {
-	max-width: theme.get-var( 'layout', 'narrow' );
-}
-
-.alignwide {
-	max-width: theme.get-var( 'layout', 'wide' );
-}
-
-.alignextrawide {
-	max-width: theme.get-var( 'layout', 'extra-wide' );
-}
-
-.alignfull {
-	width: 100vw; // maybe just unset width?
-	max-width: none;
-	margin-inline: calc( #{theme.get-var( 'sizes', 'gutter' )} * -1 );
-}
+@include layout.alignments;
 
 // RECOMMENDED STYLE
 .alignleft {


### PR DESCRIPTION
...so that they can be nested within the block-container mixin. Fixes #23.