### PR TITLE
Fixes button outline color issue

### DIFF
--- a/src/styles/utilities/_buttons.scss
+++ b/src/styles/utilities/_buttons.scss
@@ -116,6 +116,10 @@
 	padding: 0.5em 1em 0.4em;
 	font-weight: normal;
 
+	&:not(.has-text-color) {
+		color: var(--has-color);
+	}
+
 	&:hover,
 	&:focus {
 		box-shadow: 0 0 0 0.15rem var(--has-background-color);


### PR DESCRIPTION
WordPress outputs the following
```
.wp-block-button.is-style-outline>.wp-block-button__link:not(.has-text-color), .wp-block-button .wp-block-button__link.is-style-outline:not(.has-text-color) {
    color: currentColor;
}
```
which overwrites the outline text color with currentColor. This aims to solve that.